### PR TITLE
Add the possibility to set the group id from the element

### DIFF
--- a/src/Elements/GroupWrapper.php
+++ b/src/Elements/GroupWrapper.php
@@ -58,6 +58,17 @@ class GroupWrapper
     }
 
     /**
+     * @param mixed $id
+     * @return $this
+     */
+    public function setGroupId($id)
+    {
+        $this->formGroup->id($id);
+
+        return $this;
+    }
+
+    /**
      * @param $class
      * @return $this
      */

--- a/tests/BasicFormBuilderTest.php
+++ b/tests/BasicFormBuilderTest.php
@@ -546,6 +546,13 @@ class BasicFormBuilderTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testCanSetGroupId()
+    {
+        $expected = '<div class="form-group" id="test-id"><label class="control-label" for="email">Email</label><input type="text" name="email" id="email" class="form-control"></div>';
+        $result = $this->form->text('Email', 'email')->setGroupId('test-id')->render();
+        $this->assertEquals($expected, $result);
+    }
+
     public function testCanRemoveGroupClass()
     {
         $expected = '<div><label class="control-label" for="email">Email</label><input type="text" name="email" id="email" class="form-control"></div>';


### PR DESCRIPTION
That's impossible to set the group `id` attribute from the form element, only the class.

This PR adds a method called `setGroupId()` in `GroupWrapper` class, allowing to set the `id=""` attribute:

```php
BootForm::text('name')->setGroupId('foo');